### PR TITLE
getSrcWorkspacesFilter

### DIFF
--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -213,18 +213,14 @@ func getSrcWorkspacesFilter(c tfclient.ClientContexts, wsList []string) ([]*tfe.
 
 			// If multiple workspaces named similar, find exact match
 			if len(items.Items) > 1 {
-				fmt.Printf("Searched for %v and found the following %v\n", ws, items.Items)
 				for _, result := range items.Items {
-					fmt.Printf("- %v\n", result.Name)
 					if ws == result.Name {
-						fmt.Printf("WS: %v, matches  %v\n", ws, result.Name)
+						// Finding matching workspace name
 						break
 					}
 					indexMatch++
 				}
 			}
-
-			fmt.Printf("Final Matching %v, Src WS: %v, Matching %v\n", indexMatch, ws, items.Items[indexMatch].Name)
 
 			if err != nil {
 				return nil, err
@@ -268,11 +264,9 @@ func getDstWorkspacesFilter(c tfclient.ClientContexts, wsList []string) ([]*tfe.
 
 			// If multiple workspaces named similar, find exact match
 			if len(items.Items) > 1 {
-				fmt.Printf("Searched for %v and found the following %v\n", ws, items.Items)
 				for _, result := range items.Items {
-					fmt.Printf("- %v\n", result.Name)
 					if ws == result.Name {
-						fmt.Printf("WS: %v, matches  %v\n", ws, result.Name)
+						// Finding matching workspace name
 						break
 					}
 					indexMatch++


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #29 

## Description

The following was returning more than 1 result.
```
items, err := c.SourceClient.Workspaces.List(c.SourceContext, c.SourceOrganizationName, &opts) // This should only return 1 result
```

when the search filter is used, it will return multiple results eg "vnet", "carl-vnet" when searching for just "vnet'

This PR solves it for both `getSrcWorkspacesFilter()` and `getDstWorkspacesFilter()` functions

## Expectation
 Expect to only return 1 result. 

## How to'

Source TF: 
- 2 workspaces named "vnet" and "carl-vnet"
-  Config File like the following where it only specifies to modify one of the existing workspaces
 ```
"workspace-map" = [
   "vnet=vnet2"
]
``` 

Destination TF:
- Keep it clean, no migrated workspaces yet.