### PR TITLE
serials should start at 1 instead of 0

### DIFF
--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -259,7 +259,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					md5String := fmt.Sprintf("%x", md5.Sum([]byte(state)))
 
 					// Create an empty int
-					newSerial := int64(0)
+					newSerial := int64(1)
 
 					// Get properties of the state
 					currentState, _ := c.DestinationClient.StateVersions.ReadCurrent(c.DestinationContext, destWorkspaceId)


### PR DESCRIPTION
# Pull request

Noticed a bug in which state files would be created at serial 0, but TFC would overwrite it to 1. This caused the next subsequent run to create a duplicate state file when non should be created at all. 

The following fix creates state files in TFC starting at serial 1 to avoid this. 
