### PR TITLE
115 Suppport for JSON output of list projects with project Name and ID

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -21,5 +21,5 @@ var (
 func init() {
 
 	ListCmd.PersistentFlags().StringVar(&side, "side", "", "Specify source or destination side to process")
-	ListCmd.PersistentFlags().BoolVar(&jsonOut, "json", false, "Print the output in JSON format")
+	ListCmd.PersistentFlags().BoolVar(&jsonOut, "json", false, "Print the output in JSON format. Only supported with [workspaces, projects]")
 }

--- a/cmd/list/projects.go
+++ b/cmd/list/projects.go
@@ -91,7 +91,7 @@ func listProjects(c tfclient.ClientContexts, jsonOut bool) error {
 			}
 		}
 		if jsonOut {
-			projectJSON["projects"] = projectNamesAndIDs // Assign project names to the "project-names" key
+			projectJSON["projects"] = projectNamesAndIDs // Assign projects to the "projects" key
 
 			jsonData, err := json.Marshal(projectJSON)
 			if err != nil {
@@ -145,7 +145,7 @@ func listProjects(c tfclient.ClientContexts, jsonOut bool) error {
 			}
 		}
 		if jsonOut {
-			projectJSON["project-names"] = projectNamesAndIDs // Assign project names to the "project-names" key
+			projectJSON["projects"] = projectNamesAndIDs // Assign projects to the "project" key
 
 			jsonData, err := json.Marshal(projectJSON)
 			if err != nil {

--- a/cmd/list/projects.go
+++ b/cmd/list/projects.go
@@ -42,7 +42,7 @@ func listProjects(c tfclient.ClientContexts, jsonOut bool) error {
 
 	srcProjects := []*tfe.Project{}
 	projectJSON := make(map[string]interface{}) // Parent JSON object "project-names"
-	projectNames := []string{}                  // project names slice to go inside parent object "project-names"
+	projectNamesAndIDs := []map[string]string{} // project names slice to go inside parent object "project-names"
 
 	opts := tfe.ProjectListOptions{
 		ListOptions: tfe.ListOptions{
@@ -78,16 +78,20 @@ func listProjects(c tfclient.ClientContexts, jsonOut bool) error {
 			o.AddTableHeaders("Name", "ID")
 		}
 		for _, i := range srcProjects {
+			projectInfo := map[string]string{
+				"name": i.Name,
+				"id":   i.ID,
+			}
 
 			if jsonOut {
-				projectNames = append(projectNames, i.Name) // Store project name in slice
+				projectNamesAndIDs = append(projectNamesAndIDs, projectInfo) // Store project name in slice
 			}
 			if jsonOut == false {
 				o.AddTableRows(i.Name, i.ID)
 			}
 		}
 		if jsonOut {
-			projectJSON["project-names"] = projectNames // Assign project names to the "project-names" key
+			projectJSON["projects"] = projectNamesAndIDs // Assign project names to the "project-names" key
 
 			jsonData, err := json.Marshal(projectJSON)
 			if err != nil {
@@ -127,16 +131,21 @@ func listProjects(c tfclient.ClientContexts, jsonOut bool) error {
 		}
 
 		for _, i := range srcProjects {
+			projectInfo := map[string]string{
+				"name": i.Name,
+				"id":   i.ID,
+			}
 
 			if jsonOut {
-				projectNames = append(projectNames, i.Name) // Store project name in the slice
+				projectNamesAndIDs = append(projectNamesAndIDs, projectInfo) // Store project name in slice
 			}
+
 			if jsonOut == false {
 				o.AddTableRows(i.Name, i.ID)
 			}
 		}
 		if jsonOut {
-			projectJSON["project-names"] = projectNames // Assign project names to the "project-names" key
+			projectJSON["project-names"] = projectNamesAndIDs // Assign project names to the "project-names" key
 
 			jsonData, err := json.Marshal(projectJSON)
 			if err != nil {


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #115 

## Description

Implemented the ability to use --json with tfm list projects

```json
joshuatracy@joshuatracy-V1FW0Q7CVW tfm % go run main.go list projects --json --side destination | jq
{
  "project-names": [
    {
      "id": "prj-vwqYGcqYGBisJ2Zt",
      "name": "Default Project"
    },
    {
      "id": "prj-FosBGwyZ6ykAX69p",
      "name": "Health"
    },
    {
      "id": "prj-s4wCcNYWwS1zUgUy",
      "name": "Operations Team"
    },
    {
      "id": "prj-h8ZkUVGjGyLtphaj",
      "name": "Platform Team"
    },
    {
      "id": "prj-aN4CxiiYwwBrCQsG",
      "name": "Security Team"
    },
    {
      "id": "prj-MjQ9S1GEWPhgfeX8",
      "name": "TFE-Migration"
    }
  ]
}
```
