### PR TITLE
Bug state issues jm

### DIFF
--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -71,10 +71,10 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 
 	if NumberOfStates != 0 {
 		o.AddFormattedMessageCalculated("Only the %d newest workspace states will be migrated", NumberOfStates)
-	}
 
-	// If a last X amount of states is given, remove all previous states except for the last X amount
-	srcStates = srcStates[:len(srcStates) - (len(srcStates) - NumberOfStates)]
+		// If a last X amount of states is given, remove all previous states except for the last X amount
+		srcStates = srcStates[:len(srcStates)-(len(srcStates)-NumberOfStates)]
+	}
 
 	return srcStates, nil
 }
@@ -296,7 +296,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					lockWorkspace(tfclient.GetClientContexts(), destWorkspaceId)
 					fmt.Printf("Migrating state version %v serial %v for workspace Src: %v Dst: %v\n", srcstate.StateVersion, newSerial, srcworkspace.Name, destWorkSpaceName)
 					srcstate, err := c.DestinationClient.StateVersions.Create(c.DestinationContext, destWorkspaceId, tfe.StateVersionCreateOptions{
-						Type: "",
+						Type:             "",
 						Lineage:          &lineage,
 						MD5:              tfe.String(md5String),
 						Serial:           &newSerial,

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -49,7 +49,7 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 	srcStates := []*tfe.StateVersion{}
 
 	opts := tfe.StateVersionListOptions{
-		ListOptions:  tfe.ListOptions{PageNumber: 1, PageSize: NumberOfStates},
+		ListOptions:  tfe.ListOptions{PageNumber: 1, PageSize: 100},
 		Organization: c.SourceOrganizationName,
 		Workspace:    ws,
 	}
@@ -61,11 +61,8 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 
 		srcStates = append(srcStates, items.Items...)
 
+		// I think this should go after the next section
 		o.AddFormattedMessageCalculated("Found %d Workspace states", len(srcStates))
-
-		if len(srcStates) >= NumberOfStates {
-			break
-		}
 
 		if items.CurrentPage >= items.TotalPages {
 			break
@@ -217,7 +214,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 			destWorkSpaceName = wsMapCfg[srcworkspace.Name]
 		}
 
-		// Check for the exsitence of the destination workspace in the destination target
+		// Check for the existence of the destination workspace in the destination target
 		exists := doesWorkspaceExist(destWorkSpaceName, destWorkspaces)
 
 		if exists {
@@ -233,6 +230,8 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 			if err != nil {
 				return errors.Wrap(err, "failed to list state files for workspace from source")
 			}
+
+			//os.Exit(0)
 
 			// Get the destination workspace states
 			destStates, err := discoverDestStates(tfclient.GetClientContexts(), destWorkSpaceName)

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -61,15 +61,20 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 
 		srcStates = append(srcStates, items.Items...)
 
-		// I think this should go after the next section
-		o.AddFormattedMessageCalculated("Found %d Workspace states", len(srcStates))
-
 		if items.CurrentPage >= items.TotalPages {
 			break
 		}
 		opts.PageNumber = items.NextPage
 
 	}
+	o.AddFormattedMessageCalculated("Found %d Workspace states", len(srcStates))
+
+	if NumberOfStates != 0 {
+		o.AddFormattedMessageCalculated("Only the %d newest workspace states will be migrated", NumberOfStates)
+	}
+
+	// If a last X amount of states is given, remove all previous states except for the last X amount
+	srcStates = srcStates[:len(srcStates) - (len(srcStates) - NumberOfStates)]
 
 	return srcStates, nil
 }
@@ -231,8 +236,6 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 				return errors.Wrap(err, "failed to list state files for workspace from source")
 			}
 
-			//os.Exit(0)
-
 			// Get the destination workspace states
 			destStates, err := discoverDestStates(tfclient.GetClientContexts(), destWorkSpaceName)
 			if err != nil {
@@ -268,7 +271,6 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					if currentState != nil {
 						newSerial = currentState.Serial + 1
 					}
-
 
 					// Get Lineage from state file
 					plainTextState := string(state)

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -72,7 +72,13 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 	if NumberOfStates != 0 {
 		o.AddFormattedMessageCalculated("Only the %d newest workspace states will be migrated", NumberOfStates)
 
-		// If a last X amount of states is given, remove all previous states except for the last X amount
+		// If a last X amount of states is given, remove all previous states except for the last X amount.
+		// If there are fewer states to keep than there are states, set the number to keep the same amount of states
+		// there are for the workspace
+		if NumberOfStates > len(srcStates) {
+			NumberOfStates = len(srcStates)
+		}
+		
 		srcStates = srcStates[:len(srcStates)-(len(srcStates)-NumberOfStates)]
 	}
 


### PR DESCRIPTION
# Pull request

fixes #144 

## Description

The last X number of states was breaking pagination. This fix sets the pagination back to our standard, but then takes the number of workspaces to keep (if last is specified with a number) and strips off the correct number of states from the source before state migration. 

One thing to keep in mind, this does not reset the state serial in the destination, so for example:
If the source workspace has 109 states, and last 5 were set to be kept, the first state migrated, which would be the oldest state of the infra would have a serial of 105, and the last state in the source, which would be the current state of infra would have a state serial of 109. The next apply would have a serial of 110.

## Expectation

- [ ] Syntax review
- [ ] Code review && test


