### PR TITLE
Bug/api backoff retry state

### DIFF
--- a/cmd/copy/teams.go
+++ b/cmd/copy/teams.go
@@ -6,12 +6,13 @@ package copy
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/hashicorp-services/tfm/output"
 	"github.com/hashicorp-services/tfm/tfclient"
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var (

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -33,6 +33,42 @@ import (
 // Iterate backwards through the srcstate slice and append each element to a new slice
 // to create a reverse ordered slice of srcStates
 
+func rateLimitTest() {
+	// Configure the rate limit to exceed 30 requests per second, set it to a higher value.
+	requestsPerSecond := 1000
+	requestInterval := time.Second / time.Duration(requestsPerSecond)
+
+	// Create a wait group to wait for all goroutines to finish.
+	var wg sync.WaitGroup
+
+	// Launch multiple goroutines to make API requests.
+	for i := 0; i < 100; i++ { // Launch 100 goroutines
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Simulate making an API request.
+			discoverDestTeams(tfclient.GetClientContexts())
+
+			// Sleep for the specified interval before making the next request.
+			time.Sleep(requestInterval)
+		}()
+	}
+
+	// Wait for all goroutines to finish.
+	wg.Wait()
+
+	fmt.Println("All API requests completed.")
+}
+
+func makeAPIRequest() {
+	// Simulate making an API request here.
+	// You can implement logic to trigger timeouts or simulate API errors.
+	// For example, you can use a timer to simulate a timeout:
+	time.Sleep(2 * time.Second)
+	fmt.Println("API request made.")
+}
+
 func reverseSlice(input []*tfe.StateVersion) []*tfe.StateVersion {
 	inputLen := len(input)
 	output := make([]*tfe.StateVersion, inputLen)
@@ -387,6 +423,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					// // ---------------------------------------
 					// // --- end rate limiting testing code ---
 					// // ---------------------------------------
+					rateLimitTest()
 					for retry := 0; retry <= 2; retry++ {
 						srcstate, err := c.DestinationClient.StateVersions.Create(c.DestinationContext, destWorkspaceId, tfe.StateVersionCreateOptions{
 							Type:             "",

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -42,7 +42,7 @@ func rateLimitTest() {
 	var wg sync.WaitGroup
 
 	// Launch multiple goroutines to make API requests.
-	for i := 0; i < 100; i++ { // Launch 100 goroutines
+	for i := 0; i < 1000; i++ { // Launch 100 goroutines
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -375,8 +375,17 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					})
 
 					if err != nil {
-						// If there is an error output the error and move onto the next workspace.
+						// Create a file to store workspace names with errors
+						errorLogFile, err := os.Create("workspace_error_log.txt")
+						if err != nil {
+							fmt.Printf("Failed to create error log file: %v\n", err)
+							return err
+						}
+						defer errorLogFile.Close()
+
+						// If there is an error output the error, log it, and move onto the next workspace.
 						fmt.Println("failed to migrate state file. Moving onto next workspace.", err)
+						errorLogFile.WriteString(fmt.Sprintf("Failed to migrate state file for source workspace: %v\n", srcworkspace.Name))
 						break
 
 					}

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -4,7 +4,6 @@
 package copy
 
 import (
-	"crypto/md5"
 	b64 "encoding/base64"
 	"fmt"
 	"os"
@@ -296,7 +295,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					stringState := b64.StdEncoding.EncodeToString(state)
 
 					// Get the MD5 hash of the state
-					md5String := fmt.Sprintf("%x", md5.Sum([]byte(state)))
+					md5String := "test" //fmt.Sprintf("%x", md5.Sum([]byte(state)))
 
 					// Create an empty int
 					newSerial := int64(1)
@@ -332,56 +331,45 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					// Lock the destination workspace
 					lockWorkspace(tfclient.GetClientContexts(), destWorkspaceId)
 					fmt.Printf("Migrating state version %v serial %v for workspace Src: %v Dst: %v\n", srcstate.StateVersion, newSerial, srcworkspace.Name, destWorkSpaceName)
-
-					// // ---------------------------------------
-					// // --- START rate limiting testing code ---
-					// // ---------------------------------------
-					for retry := 0; retry <= 2; retry++ {
-						//rateLimitTest()
+					for retry := 0; retry <= 3; retry++ {
+						// // ------------------------------------------------------------------------------
+						// // --- START rate limiting testing code ------------------------------------------
+						// // --- Comment out when not testing ------------------------------------------
+						// // ------------------------------------------------------------------------------
 						// Configure the rate limit to exceed 30 requests per second, set it to a higher value.
-						requestsPerSecond := 1000
-						requestInterval := time.Second / time.Duration(requestsPerSecond)
+						// requestsPerSecond := 1000
+						// requestInterval := time.Second / time.Duration(requestsPerSecond)
 
-						// Create a wait group to wait for all goroutines to finish.
-						var wg sync.WaitGroup
+						// // Create a wait group to wait for all goroutines to finish.
+						// var wg sync.WaitGroup
 
-						// Launch multiple goroutines to make API requests.
-						for i := 0; i < 1000; i++ { // Launch 100 goroutines
-							wg.Add(1)
-							go func() {
-								defer wg.Done()
+						// // Launch multiple goroutines to make API requests.
+						// for i := 0; i < 1000; i++ { // Launch 100 goroutines
+						// 	wg.Add(1)
+						// 	go func() {
+						// 		defer wg.Done()
 
-								// Create a timer to implement a timeout.
-								timer := time.NewTimer(10 * time.Second) // Adjust the timeout duration as needed.
+						// 		// Simulate making an API request.
+						// 		resp, err := discoverDestTeams(tfclient.GetClientContexts())
+						// 		if err != nil {
+						// 			// Handle other errors here.
+						// 			fmt.Println("Error:", err)
+						// 			return
+						// 		}
+						// 		_ = resp
+						// 		// Sleep for the specified interval before making the next request.
+						// 		time.Sleep(requestInterval)
 
-								select {
-								case <-timer.C:
-									// Handle the timeout case.
-									fmt.Println("API request timed out. Sleeping and retrying.")
-									timer.Stop()
-									return
-								default:
-									// Simulate making an API request.
-									resp, err := discoverDestTeams(tfclient.GetClientContexts())
-									if err != nil {
-										// Handle other errors here.
-										fmt.Println("Error:", err)
-										return
-									}
-									_ = resp
-									// Sleep for the specified interval before making the next request.
-									time.Sleep(requestInterval)
-								}
-							}()
-						}
+						// 	}()
+						// }
 
-						// Wait for all goroutines to finish.
-						wg.Wait()
+						// // Wait for all goroutines to finish.
+						// wg.Wait()
 
-						fmt.Println("All API requests completed.")
-						// // ---------------------------------------
-						// // --- end rate limiting testing code ---
-						// // ---------------------------------------
+						// fmt.Println("All API requests completed.")
+						// // ------------------------------------------------------------------------------
+						// // --- end rate limiting testing code ------------------------------------------
+						// // ------------------------------------------------------------------------------
 						srcstate, err := c.DestinationClient.StateVersions.Create(c.DestinationContext, destWorkspaceId, tfe.StateVersionCreateOptions{
 							Type:             "",
 							Lineage:          &lineage,
@@ -402,7 +390,7 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 						if err != nil {
 
 							// Sleep for a moment before the next retry.
-							fmt.Println("There was an issue migrating state. Sleeping and retrying.")
+							fmt.Println("There was an issue migrating state. Sleeping for 2 seconds and retrying.")
 							time.Sleep(2 * time.Second) // Adjust the duration as needed.
 
 							return err

--- a/site/docs/commands/copy_workspace_state.md
+++ b/site/docs/commands/copy_workspace_state.md
@@ -2,8 +2,7 @@
 
 `tfm copy workspaces --state` or `tfm copy ws --state` copies a workspaces' states from source to destination org.
 
-!!! note ""
-    *NOTE: Currently ALL states will be copied over to the destination.  Future update will be the ability to update 1 or choose X number of the latest states. *
+In the event a state file encounters an error when attempting to migrate, TFM will stop migrating state files for that particular workspace and move to the next workspace.
 
 
 ![copy_ws_state](../images/copy_ws_state.png)
@@ -19,6 +18,8 @@ This flag is designed for users who only want to copy the last X number of state
 
 !!! WARNING ""
     **WARNING: This operation should not be ran more than once**
+
+In the event a state file encounters an error when attempting to migrate, TFM will stop migrating state files for that particular workspace and move to the next workspace.
 
 ![copy_ws_state_last_x](../images/copy_ws_state_last_x.png)
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -106,7 +106,7 @@ export DST_TFC_PROJECT_ID="Destination Project ID for workspaces being migrated 
 
 ### Config File
 
-A HCL file with the following as the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`. You can ls run `tfm generate --config` to create a tempalte config file for use.
+A HCL file with the following as the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`. You can also run `tfm generate --config` to create a tempalte config file for use.
 
 ```terraform
 src_tfe_hostname="tf.local.com"

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -70,6 +70,8 @@ Usage:
 
 Available Commands:
   copy        Copy command
+  delete      delete command
+  generate    generate command for generating .tfm.hcl config template
   help        Help about any command
   list        List command
 
@@ -77,6 +79,7 @@ Flags:
       --autoapprove     Auto Approve the tfm run. --autoapprove=true . false by default
       --config string   Config file, can be used to store common flags, (default is ./.tfm.hcl).
   -h, --help            help for tfm
+      --json            Print outputs in JSON (Projects and Workspaces Only)
   -v, --version         version for tfm
 
 Use "tfm [command] --help" for more information about a command.
@@ -103,7 +106,7 @@ export DST_TFC_PROJECT_ID="Destination Project ID for workspaces being migrated 
 
 ### Config File
 
-A HCL file with the following is the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`.
+A HCL file with the following as the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`. You can ls run `tfm generate --config` to create a tempalte config file for use.
 
 ```terraform
 src_tfe_hostname="tf.local.com"

--- a/site/docs/migration/example-scenarios.md
+++ b/site/docs/migration/example-scenarios.md
@@ -200,7 +200,7 @@ Each workspace in the destination should be verified a clean plan can be execute
 
 ### Example GitHub Actions Pipeline
 
-The following is an example GitHub Actions pipeline that uses the `tfm` binary. An assumption is made that some customers may want to pipeline the migration as `tfm` has been developed to be idempotent. 
+The following is an example GitHub Actions pipeline that uses the `tfm` binary. An assumption is made that some customers may want to pipeline the migration as `tfm` has been developed to be idempotent. You can also view the e2e.workflow file used for nightly testing of TFM for a more robust example. 
 
 ```yaml
 name: TFM migration pipeline

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -77,6 +77,8 @@ nav:
     - Delete:
       - General: commands/delete.md
       - Workspace: commands/delete_workspace.md
+    - Generate:
+      - General: commands/generate_config.md
   - Development:
     - MVP Details: code/mvp.md
     - Project Details: code/project-details.md

--- a/tfclient/tfclient.go
+++ b/tfclient/tfclient.go
@@ -28,6 +28,7 @@ type ClientContexts struct {
 	DestinationToken            string
 }
 
+// Create the source client and if ther is an error, retry
 func createSrcClientWithRetry(sourceConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
 	var SourceClient *tfe.Client
 	var err error
@@ -55,6 +56,7 @@ func createSrcClientWithRetry(sourceConfig *tfe.Config, maxRetries int, initialB
 	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
 }
 
+// Create the destination client and if ther is an error, retry
 func createDestClientWithRetry(destinationConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
 	var destinationClient *tfe.Client
 	var err error
@@ -84,8 +86,8 @@ func createDestClientWithRetry(destinationConfig *tfe.Config, maxRetries int, in
 
 func GetClientContexts() ClientContexts {
 
-	maxRetries := 5                   // Maximum number of retries
-	initialBackoff := 2 * time.Second // Initial backoff duration
+	maxRetries := 5                   // Maximum number of retries. Used in instances where API rate limiting or network connectivity is less than ideal.
+	initialBackoff := 2 * time.Second // Initial backoff duration. Used in instances where API rate limiting or network connectivity is less than ideal.
 
 	sourceConfig := &tfe.Config{
 		Address:           "https://" + viper.GetString("src_tfe_hostname"),
@@ -97,7 +99,7 @@ func GetClientContexts() ClientContexts {
 
 	sourceClient, err := createSrcClientWithRetry(sourceConfig, maxRetries, initialBackoff)
 	if err != nil {
-		println("AHHHHHHHHHHHHHH1")
+		println("There was an issue creating the source client connection.")
 		log.Fatal(err)
 	}
 
@@ -111,7 +113,7 @@ func GetClientContexts() ClientContexts {
 
 	destinationClient, err := createDestClientWithRetry(destinationConfig, maxRetries, initialBackoff)
 	if err != nil {
-		println("AHHHHHHHHHHHHHH2")
+		println("There was an issue creating the destination client connection.")
 		log.Fatal(err)
 	}
 

--- a/tfclient/tfclient.go
+++ b/tfclient/tfclient.go
@@ -5,7 +5,11 @@ package tfclient
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"math"
+	"net/http"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/spf13/viper"
@@ -24,25 +28,90 @@ type ClientContexts struct {
 	DestinationToken            string
 }
 
-func GetClientContexts() ClientContexts {
+func createSrcClientWithRetry(sourceConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
+	var SourceClient *tfe.Client
+	var err error
 
-	sourceConfig := &tfe.Config{
-		Address: "https://" + viper.GetString("src_tfe_hostname"),
-		Token:   viper.GetString("src_tfe_token"),
+	for retry := 0; retry <= maxRetries; retry++ {
+		SourceClient, err = tfe.NewClient(sourceConfig)
+		if err == nil {
+			// Context creation successful, exit retry loop.
+			return SourceClient, nil
+		}
+
+		// Handle the error (e.g., log it).
+		fmt.Printf("Error creating client on attempt %d: %v\n", retry+1, err)
+
+		if retry < maxRetries {
+			// Calculate the backoff duration using an exponential strategy.
+			backoff := time.Duration(math.Pow(2, float64(retry))) * initialBackoff
+
+			// Sleep for the calculated backoff duration before retrying.
+			fmt.Printf("Retrying after sleeping for %s...\n", backoff)
+			time.Sleep(backoff)
+		}
 	}
 
-	sourceClient, err := tfe.NewClient(sourceConfig)
+	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
+}
+
+func createDestClientWithRetry(destinationConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
+	var destinationClient *tfe.Client
+	var err error
+
+	for retry := 0; retry <= maxRetries; retry++ {
+		destinationClient, err = tfe.NewClient(destinationConfig)
+		if err == nil {
+			// Context creation successful, exit retry loop.
+			return destinationClient, nil
+		}
+
+		// Handle the error (e.g., log it).
+		fmt.Printf("Error creating client on attempt %d: %v\n", retry+1, err)
+
+		if retry < maxRetries {
+			// Calculate the backoff duration using an exponential strategy.
+			backoff := time.Duration(math.Pow(2, float64(retry))) * initialBackoff
+
+			// Sleep for the calculated backoff duration before retrying.
+			fmt.Printf("Retrying after sleeping for %s...\n", backoff)
+			time.Sleep(backoff)
+		}
+	}
+
+	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
+}
+
+func GetClientContexts() ClientContexts {
+
+	maxRetries := 5                   // Maximum number of retries
+	initialBackoff := 2 * time.Second // Initial backoff duration
+
+	sourceConfig := &tfe.Config{
+		Address:           "https://" + viper.GetString("src_tfe_hostname"),
+		Token:             viper.GetString("src_tfe_token"),
+		RetryServerErrors: true,
+		RetryLogHook: func(attemptNum int, resp *http.Response) {
+		},
+	}
+
+	sourceClient, err := createSrcClientWithRetry(sourceConfig, maxRetries, initialBackoff)
 	if err != nil {
+		println("AHHHHHHHHHHHHHH1")
 		log.Fatal(err)
 	}
 
 	destinationConfig := &tfe.Config{
-		Address: "https://" + viper.GetString("dst_tfc_hostname"),
-		Token:   viper.GetString("dst_tfc_token"),
+		Address:           "https://" + viper.GetString("dst_tfc_hostname"),
+		Token:             viper.GetString("dst_tfc_token"),
+		RetryServerErrors: true,
+		RetryLogHook: func(attemptNum int, resp *http.Response) {
+		},
 	}
 
-	destinationClient, err := tfe.NewClient(destinationConfig)
+	destinationClient, err := createDestClientWithRetry(destinationConfig, maxRetries, initialBackoff)
 	if err != nil {
+		println("AHHHHHHHHHHHHHH2")
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #143 

## Description

TFM is not handling API rate limiting timeouts gracefully. 

## Expectation

Terraform Cloud has an API rate limit of 30 requests per second. If TFM exceeds this then the client creation to establish connection is denied resulting in TLS handshake errors. 

TFM should
- Handle any errors that are cause by network congestion or API rate limiting and retry the connection attempt instead of failing. 
- TFM should not exit when errors are encountered for sate files for 1 workspace. TFM should stop migrating states for the workspace in question and continue to the next workspace. 

## Retry Logic

If TFM hits  an error during context creation during connection initiation it will sleep for 2 seconds and retry the connection 5 times before backing off.
```hcl
func createDestClientWithRetry(destinationConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
	var destinationClient *tfe.Client
	var err error

	for retry := 0; retry <= maxRetries; retry++ {
		destinationClient, err = tfe.NewClient(destinationConfig)
		if err == nil {
			// Context creation successful, exit retry loop.
			return destinationClient, nil
		}

		// Handle the error (e.g., log it).
		fmt.Printf("Error creating client on attempt %d: %v\n", retry+1, err)

		if retry < maxRetries {
			// Calculate the backoff duration using an exponential strategy.
			backoff := time.Duration(math.Pow(2, float64(retry))) * initialBackoff

			// Sleep for the calculated backoff duration before retrying.
			fmt.Printf("Retrying after sleeping for %s...\n", backoff)
			time.Sleep(backoff)
		}
	}

	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
}

func GetClientContexts() ClientContexts {

	maxRetries := 5                   // Maximum number of retries. Used in instances where API rate limiting or network connectivity is less than ideal.
	initialBackoff := 2 * time.Second // Initial backoff duration. Used in instances where API rate limiting or network connectivity is less than ideal.

	sourceConfig := &tfe.Config{
		Address:           "https://" + viper.GetString("src_tfe_hostname"),
		Token:             viper.GetString("src_tfe_token"),
		RetryServerErrors: true,
		RetryLogHook: func(attemptNum int, resp *http.Response) {
		},
	}

	sourceClient, err := createSrcClientWithRetry(sourceConfig, maxRetries, initialBackoff)
	if err != nil {
		println("There was an issue creating the source client connection.")
		log.Fatal(err)
	}

	destinationConfig := &tfe.Config{
		Address:           "https://" + viper.GetString("dst_tfc_hostname"),
		Token:             viper.GetString("dst_tfc_token"),
		RetryServerErrors: true,
		RetryLogHook: func(attemptNum int, resp *http.Response) {
		},
	}

	destinationClient, err := createDestClientWithRetry(destinationConfig, maxRetries, initialBackoff)
	if err != nil {
		println("There was an issue creating the destination client connection.")
		log.Fatal(err)
	}
```

## State Copy Failure Logic
If TFM encounters an error with migrating a state file for a particular workspace, it will stop migrating all states for that workspace, create a `workspace_error_log` file with the workspace in question and the error encountered, and continue to the next workspace. 

```hcl
if err != nil {
						// Create a file to store workspace names with errors
						errorLogFile, err := os.Create("workspace_error_log.txt")
						if err != nil {
							fmt.Printf("Failed to create error log file: %v\n", err)
							return err
						}
						defer errorLogFile.Close()

						// If there is an error output the error, log it, and move onto the next workspace.
						fmt.Println("failed to migrate state file. Moving onto next workspace.", err)
						errorLogFile.WriteString(fmt.Sprintf("Failed to migrate state file for source workspace: %v\n", srcworkspace.Name))
						break
```

## API Rate limit testing
Commented out code has been added to workspace-states.go for internal testing. It uses go routines to call a function 1 times in parallel resulting in TLS handshake errors from TFC. Uncomment when testing.
