### PR TITLE
Release/0.4.2

### DIFF
--- a/cmd/copy/teams.go
+++ b/cmd/copy/teams.go
@@ -6,12 +6,13 @@ package copy
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/hashicorp-services/tfm/output"
 	"github.com/hashicorp-services/tfm/tfclient"
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
-	github.com/hashicorp/go-slug v0.12.1 // indirect
+	github.com/hashicorp/go-slug v0.12.2 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -34,7 +34,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/hashicorp/go-tfe v1.32.1
+	github.com/hashicorp/go-tfe v1.34.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
-github.com/hashicorp/go-slug v0.12.1 h1:lYhmKXXonP4KGSz3JBmks6YpDRjP1cMA/yvcoPxoNw8=
-github.com/hashicorp/go-slug v0.12.1/go.mod h1:JZVtycnZZbiJ4oxpJ/zfhyfBD8XxT4f0uOSyjNLCqFY=
-github.com/hashicorp/go-tfe v1.32.1 h1:5G84t70g70xWK5U0WaYb8wLfbC5fR6dvawqCkmMN5X0=
-github.com/hashicorp/go-tfe v1.32.1/go.mod h1:Js4M/3kv14oTBlvLxqh0bbrWfosmNsEb9ad9YazsyfM=
+github.com/hashicorp/go-slug v0.12.2 h1:Gb6nxnV5GI1UVa3aLJGUj66J8AOZFnjIoYalNCp2Cbo=
+github.com/hashicorp/go-slug v0.12.2/go.mod h1:JZVtycnZZbiJ4oxpJ/zfhyfBD8XxT4f0uOSyjNLCqFY=
+github.com/hashicorp/go-tfe v1.34.0 h1:33xcVQ8sbkdPVhubpVH208+S72l6l5bFEi14363yOIE=
+github.com/hashicorp/go-tfe v1.34.0/go.mod h1:xA+N8r81ldvS7PC/DVbL+FqGsgfrcu1Ak4+6His+51s=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/site/docs/commands/copy_workspace_state.md
+++ b/site/docs/commands/copy_workspace_state.md
@@ -2,8 +2,7 @@
 
 `tfm copy workspaces --state` or `tfm copy ws --state` copies a workspaces' states from source to destination org.
 
-!!! note ""
-    *NOTE: Currently ALL states will be copied over to the destination.  Future update will be the ability to update 1 or choose X number of the latest states. *
+In the event a state file encounters an error when attempting to migrate, TFM will stop migrating state files for that particular workspace and move to the next workspace.
 
 
 ![copy_ws_state](../images/copy_ws_state.png)
@@ -19,6 +18,8 @@ This flag is designed for users who only want to copy the last X number of state
 
 !!! WARNING ""
     **WARNING: This operation should not be ran more than once**
+
+In the event a state file encounters an error when attempting to migrate, TFM will stop migrating state files for that particular workspace and move to the next workspace.
 
 ![copy_ws_state_last_x](../images/copy_ws_state_last_x.png)
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -70,6 +70,8 @@ Usage:
 
 Available Commands:
   copy        Copy command
+  delete      delete command
+  generate    generate command for generating .tfm.hcl config template
   help        Help about any command
   list        List command
 
@@ -77,6 +79,7 @@ Flags:
       --autoapprove     Auto Approve the tfm run. --autoapprove=true . false by default
       --config string   Config file, can be used to store common flags, (default is ./.tfm.hcl).
   -h, --help            help for tfm
+      --json            Print outputs in JSON (Projects and Workspaces Only)
   -v, --version         version for tfm
 
 Use "tfm [command] --help" for more information about a command.
@@ -103,7 +106,7 @@ export DST_TFC_PROJECT_ID="Destination Project ID for workspaces being migrated 
 
 ### Config File
 
-A HCL file with the following is the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`.
+A HCL file with the following as the minimum located at `/home/user/.tfm.hcl` or specified by `--config config_file`. You can also run `tfm generate --config` to create a tempalte config file for use.
 
 ```terraform
 src_tfe_hostname="tf.local.com"

--- a/site/docs/migration/example-scenarios.md
+++ b/site/docs/migration/example-scenarios.md
@@ -200,7 +200,7 @@ Each workspace in the destination should be verified a clean plan can be execute
 
 ### Example GitHub Actions Pipeline
 
-The following is an example GitHub Actions pipeline that uses the `tfm` binary. An assumption is made that some customers may want to pipeline the migration as `tfm` has been developed to be idempotent. 
+The following is an example GitHub Actions pipeline that uses the `tfm` binary. An assumption is made that some customers may want to pipeline the migration as `tfm` has been developed to be idempotent. You can also view the e2e.workflow file used for nightly testing of TFM for a more robust example. 
 
 ```yaml
 name: TFM migration pipeline

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -77,6 +77,8 @@ nav:
     - Delete:
       - General: commands/delete.md
       - Workspace: commands/delete_workspace.md
+    - Generate:
+      - General: commands/generate_config.md
   - Development:
     - MVP Details: code/mvp.md
     - Project Details: code/project-details.md

--- a/tfclient/tfclient.go
+++ b/tfclient/tfclient.go
@@ -5,7 +5,11 @@ package tfclient
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"math"
+	"net/http"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/spf13/viper"
@@ -24,25 +28,92 @@ type ClientContexts struct {
 	DestinationToken            string
 }
 
-func GetClientContexts() ClientContexts {
+// Create the source client and if ther is an error, retry
+func createSrcClientWithRetry(sourceConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
+	var SourceClient *tfe.Client
+	var err error
 
-	sourceConfig := &tfe.Config{
-		Address: "https://" + viper.GetString("src_tfe_hostname"),
-		Token:   viper.GetString("src_tfe_token"),
+	for retry := 0; retry <= maxRetries; retry++ {
+		SourceClient, err = tfe.NewClient(sourceConfig)
+		if err == nil {
+			// Context creation successful, exit retry loop.
+			return SourceClient, nil
+		}
+
+		// Handle the error (e.g., log it).
+		fmt.Printf("Error creating client on attempt %d: %v\n", retry+1, err)
+
+		if retry < maxRetries {
+			// Calculate the backoff duration using an exponential strategy.
+			backoff := time.Duration(math.Pow(2, float64(retry))) * initialBackoff
+
+			// Sleep for the calculated backoff duration before retrying.
+			fmt.Printf("Retrying after sleeping for %s...\n", backoff)
+			time.Sleep(backoff)
+		}
 	}
 
-	sourceClient, err := tfe.NewClient(sourceConfig)
+	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
+}
+
+// Create the destination client and if ther is an error, retry
+func createDestClientWithRetry(destinationConfig *tfe.Config, maxRetries int, initialBackoff time.Duration) (*tfe.Client, error) {
+	var destinationClient *tfe.Client
+	var err error
+
+	for retry := 0; retry <= maxRetries; retry++ {
+		destinationClient, err = tfe.NewClient(destinationConfig)
+		if err == nil {
+			// Context creation successful, exit retry loop.
+			return destinationClient, nil
+		}
+
+		// Handle the error (e.g., log it).
+		fmt.Printf("Error creating client on attempt %d: %v\n", retry+1, err)
+
+		if retry < maxRetries {
+			// Calculate the backoff duration using an exponential strategy.
+			backoff := time.Duration(math.Pow(2, float64(retry))) * initialBackoff
+
+			// Sleep for the calculated backoff duration before retrying.
+			fmt.Printf("Retrying after sleeping for %s...\n", backoff)
+			time.Sleep(backoff)
+		}
+	}
+
+	return nil, fmt.Errorf("Max retries reached. Last error: %v", err)
+}
+
+func GetClientContexts() ClientContexts {
+
+	maxRetries := 5                   // Maximum number of retries. Used in instances where API rate limiting or network connectivity is less than ideal.
+	initialBackoff := 2 * time.Second // Initial backoff duration. Used in instances where API rate limiting or network connectivity is less than ideal.
+
+	sourceConfig := &tfe.Config{
+		Address:           "https://" + viper.GetString("src_tfe_hostname"),
+		Token:             viper.GetString("src_tfe_token"),
+		RetryServerErrors: true,
+		RetryLogHook: func(attemptNum int, resp *http.Response) {
+		},
+	}
+
+	sourceClient, err := createSrcClientWithRetry(sourceConfig, maxRetries, initialBackoff)
 	if err != nil {
+		println("There was an issue creating the source client connection.")
 		log.Fatal(err)
 	}
 
 	destinationConfig := &tfe.Config{
-		Address: "https://" + viper.GetString("dst_tfc_hostname"),
-		Token:   viper.GetString("dst_tfc_token"),
+		Address:           "https://" + viper.GetString("dst_tfc_hostname"),
+		Token:             viper.GetString("dst_tfc_token"),
+		RetryServerErrors: true,
+		RetryLogHook: func(attemptNum int, resp *http.Response) {
+		},
 	}
 
-	destinationClient, err := tfe.NewClient(destinationConfig)
+	destinationClient, err := createDestClientWithRetry(destinationConfig, maxRetries, initialBackoff)
 	if err != nil {
+		println("There was an issue creating the destination client connection.")
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #146 #145 #140 

## Description

- Support for state file pagination. TFM will not copy all state files for a given workspace instead of just 20.
- Wait and retry logic during client context creation to assist in handling API rate limiting in Terraform Cloud.
- State file error handling implemented. If 1 state file for a given workspace fails to migrate TFM will stop migrating workspaces for the given workspace and proceed to the next workspace. `workspace_error_log.txt` will be generated in the working directory with a list of workspaces that had state errors.


