### PR TITLE
Release/0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] (September 19, 2023)
+- Error logs created during state copy failures are now unique with a timestamp instead of being overwritten.
+
 ## [0.4.2] (September 18, 2023)
 
 - TFM now retries connections in the event network issues or API rate limiting prevents an operation from taking place. __issue__ #143

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -109,7 +109,7 @@ func discoverSrcStates(c tfclient.ClientContexts, ws string, NumberOfStates int)
 		if NumberOfStates > len(srcStates) {
 			NumberOfStates = len(srcStates)
 		}
-		
+
 		srcStates = srcStates[:len(srcStates)-(len(srcStates)-NumberOfStates)]
 	}
 
@@ -383,8 +383,12 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 					})
 
 					if err != nil {
+						// Get the current timestamp and format it as a string
+						timestamp := time.Now().Format(time.RFC850)
+
 						// Create a file to store workspace names with errors
-						errorLogFile, err := os.Create("workspace_error_log.txt")
+						errorLogFileName := fmt.Sprintf("workspace_error_log_%s.txt", timestamp)
+						errorLogFile, err := os.Create(errorLogFileName)
 						if err != nil {
 							fmt.Printf("Failed to create error log file: %v\n", err)
 							return err

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@
 package version
 
 var (
-	Version    = "0.4.2"
+	Version    = "0.4.3"
 	Prerelease = ""
 	Build      = ""
 	Date       = ""


### PR DESCRIPTION
# Pull request
Updating the error log that gets created if a failure to copy state happens to now create a unique file name based on RFC850 timestamp.
