### PR TITLE
Fix/workspace creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1](https://github.com/hashicorp-services/tfm/compare/v0.12.0...v0.12.1) (2025-02-27)
+
+### Bug Fixes
+
+- Fixes issue [#283](https://github.com/hashicorp-services/tfm/issues/283)
+- Remove the nuke command due to the above issue
+
 ## [0.12.0](https://github.com/hashicorp-services/tfm/compare/v0.11.3...v0.12.0) (2025-02-14)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ There are differences between Terraform OSS / CE / Core migrations and Terraform
   - `copy workspaces --state --last`
   - `delete workspace`
   - `delete workspaces-vcs`
-  - `nuke`
 
 ## Architectural Decisions Record (ADR)
 

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -444,7 +444,7 @@ func copyWorkspaces(c tfclient.ClientContexts, wsMapCfg map[string]string) error
 
 		// Copy tags over
 		var tag []*tfe.Tag
-		workspaceSource := "tfm"
+		// workspaceSource := "tfm"
 
 		for _, t := range srcworkspace.TagNames {
 			tag = append(tag, &tfe.Tag{Name: t})
@@ -475,8 +475,6 @@ func copyWorkspaces(c tfclient.ClientContexts, wsMapCfg map[string]string) error
 				Name:               &destWorkSpaceName,
 				QueueAllRuns:       &srcworkspace.QueueAllRuns,
 				SpeculativeEnabled: &srcworkspace.SpeculativeEnabled,
-				SourceName:         &workspaceSource, // beta may remove
-				// SourceURL:                  &srcworkspace.SourceURL, // beta
 				StructuredRunOutputEnabled: &srcworkspace.StructuredRunOutputEnabled,
 				TerraformVersion:           &srcworkspace.TerraformVersion,
 				TriggerPrefixes:            srcworkspace.TriggerPrefixes,

--- a/cmd/core/createworkspaces.go
+++ b/cmd/core/createworkspaces.go
@@ -133,13 +133,9 @@ func createWorkspace(c tfclient.DestinationContexts, workspaceName string) error
 	var tag []*tfe.Tag
 	tag = append(tag, &tfe.Tag{Name: "tfm"})
 
-	// This is an invisible attribute that the tfm nuke workspaces command uses to identify workspaces created by tfm for easy destruction later
-	workspaceSource := "tfm"
-
 	_, err := c.DestinationClient.Workspaces.Create(c.DestinationContext, c.DestinationOrganizationName, tfe.WorkspaceCreateOptions{
 		Name:       &workspaceName,
 		Tags:       tag,
-		SourceName: &workspaceSource,
 	})
 	return err
 }

--- a/cmd/nuke/nuke.go
+++ b/cmd/nuke/nuke.go
@@ -1,19 +1,19 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package nuke
+// package nuke
 
-import (
-	"github.com/spf13/cobra"
-)
+// import (
+// 	"github.com/spf13/cobra"
+// )
 
-var (
-	NukeCmd = &cobra.Command{
-		Use:   "nuke",
-		Short: "nuke command",
-		Long:  "nuke objects in an org. DANGER this will delete things!",
-		Hidden: true,
-	}
-)
+// var (
+// 	NukeCmd = &cobra.Command{
+// 		Use:   "nuke",
+// 		Short: "nuke command",
+// 		Long:  "nuke objects in an org. DANGER this will delete things!",
+// 		Hidden: true,
+// 	}
+// )
 
-func init() {}
+// func init() {}

--- a/cmd/nuke/workspaces.go
+++ b/cmd/nuke/workspaces.go
@@ -1,143 +1,143 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// // Copyright (c) HashiCorp, Inc.
+// // SPDX-License-Identifier: MPL-2.0
 
-package nuke
+// package nuke
 
-import (
-	"fmt"
-	"strings"
+// import (
+// 	"fmt"
+// 	"strings"
 
-	"github.com/hashicorp-services/tfm/output"
-	"github.com/hashicorp-services/tfm/tfclient"
-	tfe "github.com/hashicorp/go-tfe"
-	"github.com/spf13/cobra"
-)
+// 	"github.com/hashicorp-services/tfm/output"
+// 	"github.com/hashicorp-services/tfm/tfclient"
+// 	tfe "github.com/hashicorp/go-tfe"
+// 	"github.com/spf13/cobra"
+// )
 
-var (
-	o output.Output
+// var (
+// 	o output.Output
 
-	// `tfm nuke workspaces` command
-	workspacesNukeCmd = &cobra.Command{
-		Use:     "workspaces",
-		Aliases: []string{"ws"},
-		Short:   "Workspaces command",
-		Long:    "Nuke Workspaces in an org",
-		Run: func(cmd *cobra.Command, args []string) {
-			nukeWorkspaces(tfclient.GetClientContexts())
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			o.Close()
-		},
-	}
-)
+// 	// `tfm nuke workspaces` command
+// 	workspacesNukeCmd = &cobra.Command{
+// 		Use:     "workspaces",
+// 		Aliases: []string{"ws"},
+// 		Short:   "Workspaces command",
+// 		Long:    "Nuke Workspaces in an org",
+// 		Run: func(cmd *cobra.Command, args []string) {
+// 			nukeWorkspaces(tfclient.GetClientContexts())
+// 		},
+// 		PostRun: func(cmd *cobra.Command, args []string) {
+// 			o.Close()
+// 		},
+// 	}
+// )
 
-func init() {
-	// Add commands
-	NukeCmd.AddCommand(workspacesNukeCmd)
-}
+// func init() {
+// 	// Add commands
+// 	NukeCmd.AddCommand(workspacesNukeCmd)
+// }
 
-func nukeWorkspaces(c tfclient.ClientContexts) error {
+// func nukeWorkspaces(c tfclient.ClientContexts) error {
 
-	workspaces := listWorkspaces(c)
-	workspacesToNuke := []*tfe.Workspace{}
+// 	workspaces := listWorkspaces(c)
+// 	workspacesToNuke := []*tfe.Workspace{}
 
-	for _, workspace := range workspaces {
-		if workspace.SourceName == "tfm" {
-			workspacesToNuke = append(workspacesToNuke, workspace)
-		}
-	}
+// 	for _, workspace := range workspaces {
+// 		if workspace.SourceName == "tfm" {
+// 			workspacesToNuke = append(workspacesToNuke, workspace)
+// 		}
+// 	}
 
-	if len(workspacesToNuke) > 0 {
-		o.AddFormattedMessageCalculated("Found %d Workspaces created by tfm to remove", len(workspacesToNuke))
-		o.AddTableHeaders("Name", "Description", "ExecutionMode", "VCS Repo", "Locked", "TF Version", "Workspace Source")
+// 	if len(workspacesToNuke) > 0 {
+// 		o.AddFormattedMessageCalculated("Found %d Workspaces created by tfm to remove", len(workspacesToNuke))
+// 		o.AddTableHeaders("Name", "Description", "ExecutionMode", "VCS Repo", "Locked", "TF Version")
 
-		for _, i := range workspacesToNuke {
-			ws_repo := ""
+// 		for _, i := range workspacesToNuke {
+// 			ws_repo := ""
 
-			if i.VCSRepo != nil {
-				ws_repo = i.VCSRepo.DisplayIdentifier
-			}
-			o.AddTableRows(i.Name, i.Description, i.ExecutionMode, ws_repo, i.Locked, i.TerraformVersion, i.SourceName)
-		}
-		o.Close()
+// 			if i.VCSRepo != nil {
+// 				ws_repo = i.VCSRepo.DisplayIdentifier
+// 			}
+// 			o.AddTableRows(i.Name, i.Description, i.ExecutionMode, ws_repo, i.Locked, i.TerraformVersion)
+// 		}
+// 		o.Close()
 
-		o.AddFormattedMessageCalculatedDanger("Are you sure you want to proceed? %d Workspaces will be deleted!", len(workspacesToNuke))
-		if confirm() {
-			for _, i := range workspacesToNuke {
-				c.DestinationClient.Workspaces.DeleteByID(c.DestinationContext, i.ID)
-			}
+// 		o.AddFormattedMessageCalculatedDanger("Are you sure you want to proceed? %d Workspaces will be deleted!", len(workspacesToNuke))
+// 		if confirm() {
+// 			for _, i := range workspacesToNuke {
+// 				c.DestinationClient.Workspaces.DeleteByID(c.DestinationContext, i.ID)
+// 			}
 
-			o.AddFormattedMessageCalculatedDanger("%d Workspaces have been nuked!", len(workspacesToNuke))
+// 			o.AddFormattedMessageCalculatedDanger("%d Workspaces have been nuked!", len(workspacesToNuke))
 
-		} else {
-			o.AddPassUserProvided("Nuke Disarmed!")
-		}
+// 		} else {
+// 			o.AddPassUserProvided("Nuke Disarmed!")
+// 		}
 
-	} else {
-		fmt.Print("No workspaces created by tfm were found")
-	}
+// 	} else {
+// 		fmt.Print("No workspaces created by tfm were found")
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func listWorkspaces(c tfclient.ClientContexts) []*tfe.Workspace {
+// func listWorkspaces(c tfclient.ClientContexts) []*tfe.Workspace {
 
-	workspaces := []*tfe.Workspace{}
+// 	workspaces := []*tfe.Workspace{}
 
-	opts := tfe.WorkspaceListOptions{
-		ListOptions: tfe.ListOptions{
-			PageNumber: 1,
-			PageSize:   100},
-	}
+// 	opts := tfe.WorkspaceListOptions{
+// 		ListOptions: tfe.ListOptions{
+// 			PageNumber: 1,
+// 			PageSize:   100},
+// 	}
 
-	o.AddMessageUserProvided("Getting list of workspaces from: ", c.DestinationHostname)
+// 	o.AddMessageUserProvided("Getting list of workspaces from: ", c.DestinationHostname)
 
-	for {
-		items, err := c.DestinationClient.Workspaces.List(c.DestinationContext, c.DestinationOrganizationName, &opts)
+// 	for {
+// 		items, err := c.DestinationClient.Workspaces.List(c.DestinationContext, c.DestinationOrganizationName, &opts)
 
-		if err != nil {
-			fmt.Println("Error With retrieving Workspaces from ", c.DestinationHostname, " : Error ", err)
-			// return err
-		}
+// 		if err != nil {
+// 			fmt.Println("Error With retrieving Workspaces from ", c.DestinationHostname, " : Error ", err)
+// 			// return err
+// 		}
 
-		workspaces = append(workspaces, items.Items...)
+// 		workspaces = append(workspaces, items.Items...)
 
-		if items.CurrentPage >= items.TotalPages {
-			break
-		}
-		opts.PageNumber = items.NextPage
-	}
+// 		if items.CurrentPage >= items.TotalPages {
+// 			break
+// 		}
+// 		opts.PageNumber = items.NextPage
+// 	}
 
-	return workspaces
-}
+// 	return workspaces
+// }
 
-func confirm() bool {
+// func confirm() bool {
 
-	var input string
+// 	var input string
 
-	fmt.Printf("Do you want to continue with this operation? [y|n]: ")
+// 	fmt.Printf("Do you want to continue with this operation? [y|n]: ")
 
-	auto, err := NukeCmd.Flags().GetBool("autoapprove")
+// 	auto, err := NukeCmd.Flags().GetBool("autoapprove")
 
-	if err != nil {
-		fmt.Println("Error Retrieving autoapprove flag value: ", err)
-	}
+// 	if err != nil {
+// 		fmt.Println("Error Retrieving autoapprove flag value: ", err)
+// 	}
 
-	// Check if --autoapprove=false
-	if !auto {
-		_, err := fmt.Scanln(&input)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		input = "y"
-		fmt.Println("y(autoapprove=true)")
-	}
+// 	// Check if --autoapprove=false
+// 	if !auto {
+// 		_, err := fmt.Scanln(&input)
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 	} else {
+// 		input = "y"
+// 		fmt.Println("y(autoapprove=true)")
+// 	}
 
-	input = strings.ToLower(input)
+// 	input = strings.ToLower(input)
 
-	if input == "y" || input == "yes" {
-		return true
-	}
-	return false
-}
+// 	if input == "y" || input == "yes" {
+// 		return true
+// 	}
+// 	return false
+// }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hashicorp-services/tfm/cmd/helper"
 	"github.com/hashicorp-services/tfm/cmd/list"
 	"github.com/hashicorp-services/tfm/cmd/lock"
-	"github.com/hashicorp-services/tfm/cmd/nuke"
+	// "github.com/hashicorp-services/tfm/cmd/nuke"
 	"github.com/hashicorp-services/tfm/cmd/unlock"
 	"github.com/hashicorp-services/tfm/output"
 	"github.com/hashicorp-services/tfm/version"
@@ -96,7 +96,7 @@ func init() {
 	// Available commands required after "tfm"
 	RootCmd.AddCommand(copy.CopyCmd)
 	RootCmd.AddCommand(list.ListCmd)
-	RootCmd.AddCommand(nuke.NukeCmd)
+	// RootCmd.AddCommand(nuke.NukeCmd)
 	RootCmd.AddCommand(delete.DeleteCmd)
 	RootCmd.AddCommand(generate.GenerateCmd)
 	RootCmd.AddCommand(lock.LockCmd)

--- a/site/docs/commands/core_create-workspaces.md
+++ b/site/docs/commands/core_create-workspaces.md
@@ -47,9 +47,9 @@ As an example, the below metadata would create 2 TFC/TFE workspaces with the nam
 
 If a workspace already exists with the name of the repository tfm will return an error and continue on to the next workspace creation attempt.
 
-## Cleaning Up
+<!-- ## Cleaning Up
 
-If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands.
+If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands. -->
 
 ## Out of Band Workspace Creation
 

--- a/site/docs/commands/core_link-vcs.md
+++ b/site/docs/commands/core_link-vcs.md
@@ -21,6 +21,6 @@ tfm will update the workspace settings using the `vcs_provider_id` defined in th
 
 You can create workspaces using the terraform tfe provider instead of tfm. As long as the workspace names match the constructed workspace name that tfm is looking for then the state will still be uploaded. See the documentation for the `tfm create-workspaces` command for more information regarding workspace name creation.
 
-## Cleaning Up
+<!-- ## Cleaning Up
 
-If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands.
+If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands. -->

--- a/site/docs/commands/core_migrate.md
+++ b/site/docs/commands/core_migrate.md
@@ -29,11 +29,10 @@ tfm will run the following commands in the following order when the migrate comm
 `tfm core upload-state`
 `tfm core link-vcs`
 
-
 ## Flags
 
 `--include remove-backend` will add the `tfm core remove-backend` command to be run last as part of the `tfm core migrate` command. This requires a VCS API token with write permissions to the VCS repositories.
 
-## Cleaning Up
+<!-- ## Cleaning Up
 
-If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands.
+If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands. -->

--- a/site/docs/commands/core_upload-state.md
+++ b/site/docs/commands/core_upload-state.md
@@ -15,7 +15,7 @@ Running this command multiple times will result in the same state file being upl
 
 You can create workspaces using the terraform tfe provider instead of tfm. As long as the workspace names match the constructed workspace name that tfm is looking for then the state will still be uploaded. See the documentation for the `tfm create-workspaces` command for more information regarding workspace name creation.
 
-## Cleaning Up
+<!-- ## Cleaning Up
 
 If something goes wrong and you wish to cleanup the workspaces and start the process over you can run the command `tfm nuke workspaces` to delete any workspaces created with tfm commands.
-
+ -->

--- a/tfe-migration.md
+++ b/tfe-migration.md
@@ -164,9 +164,9 @@ Note: This command will ask for confirmation, however this is a destructive oper
 This command will look at the `.tfm` configuration for the workspaces on the source that should have their VCS connection removed. This would be utilized after a migration can been completed, and the existing VCS connections on the source should be removed from the workspaces, so runs are no longer triggered by VCS
 Note: This command will ask for confirmation. The source workspaces will not be deleted, only their VCS connection, which can be added back manually if needed.
 
-### Nuke
+<!-- ### Nuke
 
-If workspaces that have been created in the destination organization need to be destroyed, `tfm nuke workspace` can be used to remove all workspaces that tfm created. This is done by listing all workspaces in the destination organization and checking if the `SourceName` is set to `tfm`. This command will prompt for confirmation. If Confirmed tfm will delete the workspaces. This is a destructive operation and the workspaces can not be recovered.
+If workspaces that have been created in the destination organization need to be destroyed, `tfm nuke workspace` can be used to remove all workspaces that tfm created. This is done by listing all workspaces in the destination organization and checking if the `SourceName` is set to `tfm`. This command will prompt for confirmation. If Confirmed tfm will delete the workspaces. This is a destructive operation and the workspaces can not be recovered. -->
 
 ### Lock & Unlock
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@
 package version
 
 var (
-	Version    = "0.12.0"
+	Version    = "0.12.1"
 	Prerelease = ""
 	Build      = ""
 	Date       = ""


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #283 

## Description

tfm will no longer set the source attribute on a workspace, as this was causing issues when trying to use the tfe provider to manage a workspace that tfm created. 
As a consequence of removing this, the `nuke` command has been removed as the source attribute was used to track what workspaces were safe for removal
