### PR TITLE
Set User-Agent header for source and destination TFE clients

### DIFF
--- a/tfclient/tfclient.go
+++ b/tfclient/tfclient.go
@@ -93,9 +93,11 @@ func GetClientContexts() ClientContexts {
 		Address:           "https://" + viper.GetString("src_tfe_hostname"),
 		Token:             viper.GetString("src_tfe_token"),
 		RetryServerErrors: true,
+		Headers:           make(http.Header),
 		RetryLogHook: func(attemptNum int, resp *http.Response) {
 		},
 	}
+	sourceConfig.Headers.Set("User-Agent", "tfm")
 
 	sourceClient, err := createSrcClientWithRetry(sourceConfig, maxRetries, initialBackoff)
 	if err != nil {
@@ -107,9 +109,11 @@ func GetClientContexts() ClientContexts {
 		Address:           "https://" + viper.GetString("dst_tfc_hostname"),
 		Token:             viper.GetString("dst_tfc_token"),
 		RetryServerErrors: true,
+		Headers:           make(http.Header),
 		RetryLogHook: func(attemptNum int, resp *http.Response) {
 		},
 	}
+	destinationConfig.Headers.Set("User-Agent", "tfm")
 
 	destinationClient, err := createDestClientWithRetry(destinationConfig, maxRetries, initialBackoff)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces enhancements to the `GetClientContexts` function in `tfclient/tfclient.go` to include custom HTTP headers, specifically setting a `User-Agent` for both source and destination configurations.

### Enhancements to HTTP client configuration:

* Added a `Headers` field to both `sourceConfig` and `destinationConfig` and initialized it using `http.Header`. (`[[1]](diffhunk://#diff-8c6d049880b93be2d303b7571f268e036af5002878285daa5cce44b0babb49e2R96-R100)`, `[[2]](diffhunk://#diff-8c6d049880b93be2d303b7571f268e036af5002878285daa5cce44b0babb49e2R112-R116)`)
* Set the `User-Agent` header to "tfm" for both source and destination configurations. (`[[1]](diffhunk://#diff-8c6d049880b93be2d303b7571f268e036af5002878285daa5cce44b0babb49e2R96-R100)`, `[[2]](diffhunk://#diff-8c6d049880b93be2d303b7571f268e036af5002878285daa5cce44b0babb49e2R112-R116)`)