### PR TITLE
Release/0.15.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ terraform_config_metadata.json
 dist/
 
 *.DS_Store*
+
+# Demo files
+demo/

--- a/cmd/copy/workspaces-run-triggers.go
+++ b/cmd/copy/workspaces-run-triggers.go
@@ -38,6 +38,13 @@ func copyRunTriggers(c tfclient.ClientContexts) error {
 			destWorkSpaceName = wsMapCfg[srcWorkspace.Name]
 		}
 
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
+		}
+
 		destWorkSpaceID, err := getWorkspaceId(tfclient.GetClientContexts(), destWorkSpaceName)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get the ID of the destination Workspace that matches the Name of the Source Workspace: "+srcWorkspace.Name)
@@ -120,11 +127,11 @@ func copyRunTriggers(c tfclient.ClientContexts) error {
 						return errors.Wrap(err, "Failed to create run trigger in destination workspace: "+destWorkSpaceName)
 					}
 					o.AddFormattedMessageCalculated2("Created run trigger for workspace %v to %v", destWorkSpaceName, runTriggerWorkspaceName)
-				} else { 
+				} else {
 					o.AddFormattedMessageCalculated("Workspace named %v does not exist in destination. Not able to setup Run Trigger", runTriggerWorkspaceName)
 				}
 			}
-		} 
+		}
 	}
 	return nil
 }

--- a/cmd/copy/workspaces-state-sharing.go
+++ b/cmd/copy/workspaces-state-sharing.go
@@ -40,6 +40,13 @@ func copyRemoteStateSharing(c tfclient.ClientContexts, consolidateGlobal bool) e
 			destWorkSpaceName = wsMapCfg[srcWorkspace.Name]
 		}
 
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
+		}
+
 		destWorkSpaceID, err := getWorkspaceId(tfclient.GetClientContexts(), destWorkSpaceName)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get the ID of the destination Workspace that matches the Name of the Source Workspace: "+srcWorkspace.Name)
@@ -48,6 +55,13 @@ func copyRemoteStateSharing(c tfclient.ClientContexts, consolidateGlobal bool) e
 		// Check if the destination Workspace name differs from the source name
 		if len(wsMapCfg) > 0 {
 			destWorkSpaceName = wsMapCfg[srcWorkspace.Name]
+		}
+
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
 		}
 
 		// Ensure the destination workspace exists in the destination target
@@ -154,7 +168,7 @@ func copyRemoteStateSharing(c tfclient.ClientContexts, consolidateGlobal bool) e
 
 					// Get the list of workspaces in the destination
 					destinationWorkspaceList, err := lookupWorkspaces(c, "destination")
-					
+
 					if err != nil {
 						return errors.Wrap(err, "failed to list Workspaces from destination")
 					}

--- a/cmd/copy/workspaces-states.go
+++ b/cmd/copy/workspaces-states.go
@@ -258,6 +258,13 @@ func copyStates(c tfclient.ClientContexts, NumberOfStates int) error {
 			destWorkSpaceName = wsMapCfg[srcworkspace.Name]
 		}
 
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
+		}
+
 		// Check for the existence of the destination workspace in the destination target
 		exists := doesWorkspaceExist(destWorkSpaceName, destWorkspaces)
 

--- a/cmd/copy/workspaces-teamaccess.go
+++ b/cmd/copy/workspaces-teamaccess.go
@@ -250,6 +250,13 @@ func copyWsTeamAccess(c tfclient.ClientContexts) error {
 			destWorkSpaceName = wsMapCfg[srcworkspace.Name]
 		}
 
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
+		}
+
 		if !doesWorkspaceExist(destWorkSpaceName, destWorkspaces) {
 			return errors.New(" Destination Workspace not found")
 		}

--- a/cmd/copy/workspaces-vars.go
+++ b/cmd/copy/workspaces-vars.go
@@ -62,16 +62,16 @@ func variableCopy(c tfclient.ClientContexts, sourceWorkspaceID string, destinati
 			//Create the variable in the destination workspace but skip any sensitive ones
 			if workspaceVar.Sensitive {
 				o.AddMessageUserProvided(destVarName, "is sensitive and will not be copied")
-		} else {
-			//Create the variable in the destination workspace
-			o.AddMessageUserProvided("Copying", destVarName)
-			_, err := c.DestinationClient.Variables.Create(c.DestinationContext, destinationWorkspaceID, variableOpts)
-			if err != nil {
-				fmt.Println("Could not create Workspace variable.\n\n Error:", err.Error())
-				return err
+			} else {
+				//Create the variable in the destination workspace
+				o.AddMessageUserProvided("Copying", destVarName)
+				_, err := c.DestinationClient.Variables.Create(c.DestinationContext, destinationWorkspaceID, variableOpts)
+				if err != nil {
+					fmt.Println("Could not create Workspace variable.\n\n Error:", err.Error())
+					return err
+				}
 			}
-		} 
-	} else {
+		} else {
 			//Create the variable in the destination workspace
 			o.AddMessageUserProvided("Copying", destVarName)
 			_, err := c.DestinationClient.Variables.Create(c.DestinationContext, destinationWorkspaceID, variableOpts)
@@ -123,6 +123,13 @@ func copyVariables(c tfclient.ClientContexts, skipSecure bool) error {
 		// Check if the destination Workspace name differs from the source name
 		if len(wsMapCfg) > 0 {
 			destWorkSpaceName = wsMapCfg[srcworkspace.Name]
+		}
+
+		// Check if the workspace name prefix and suffix are set
+		if len(wsNamePrefix) > 0 || len(wsNameSuffix) > 0 {
+			srcworkspaceSlice := []*tfe.Workspace{{Name: destWorkSpaceName}}
+			newDestWorkspaceName := standardizeNamingConvention(srcworkspaceSlice, wsNamePrefix, wsNameSuffix)
+			destWorkSpaceName = newDestWorkspaceName[0].Name
 		}
 
 		// Ensure the destination workspace exists in the destination target


### PR DESCRIPTION
This pull request introduces a consistent mechanism across multiple workspace copy operations to apply standardized naming conventions—specifically, prefix and suffix handling—to destination workspace names when copying resources. This ensures that the destination workspace names conform to user-specified naming patterns in all relevant copy commands.

**Naming convention enhancements:**

* Added logic to `copyRunTriggers`, `copyRemoteStateSharing`, `copyStates`, `copyWsTeamAccess`, and `copyVariables` functions to check for and apply workspace name prefixes and suffixes using the `standardizeNamingConvention` function before proceeding with further operations. This ensures destination workspace names are consistently formatted according to provided naming rules. [[1]](diffhunk://#diff-8ea0c478e0e9a21417913c90f2a28ae90d425e1dd767f01320eda24fd427033cR41-R47) [[2]](diffhunk://#diff-75e753ff9ee016913a754233b1ec142bf007cf8efbf68c8c91ebf190ade08210R43-R49) [[3]](diffhunk://#diff-75e753ff9ee016913a754233b1ec142bf007cf8efbf68c8c91ebf190ade08210R60-R66) [[4]](diffhunk://#diff-087d079dd429fa180bdb1b6704cd1a935faa4f4980168c8ce4b6a777978425bcR261-R267) [[5]](diffhunk://#diff-fad93001b1458dc80a6cb890261fccb7815917e2213c31a7531a46d124393b7fR253-R259) [[6]](diffhunk://#diff-6a2ec71290dc18dd300619299a4707b3e00b39a14b5c56fcd28fdd8023b1f504R128-R134)