### PR TITLE
Release/0.16.0

### DIFF
--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -780,7 +780,7 @@ func excludeWorkspaceRemoteStateResources(c tfclient.ClientContexts, workspaceLi
 		opts.ListOptions.PageNumber = 1 // reset pagination for each workspace
 
 		for {
-			resources, err := c.DestinationClient.WorkspaceResources.List(context.Background(), ws.ID, opts)
+			resources, err := c.SourceClient.WorkspaceResources.List(context.Background(), ws.ID, opts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list workspace resources - : %w", err)
 			}

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -785,7 +785,6 @@ func excludeWorkspaceRemoteStateResources(c tfclient.ClientContexts, workspaceLi
 				return nil, fmt.Errorf("failed to list workspace resources - : %w", err)
 			}
 			for _, resource := range resources.Items {
-				
 				if resource.ProviderType == "data.terraform_remote_state" {
 					fmt.Printf("\nSkipping workspace %s due to terraform_remote_state resource\n", ws.Name)
 					hasRemoteState = true

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -304,9 +304,6 @@ func getSrcWorkspacesCfg(c tfclient.ClientContexts) ([]*tfe.Workspace, error) {
 		}
 		o.AddFormattedMessageCalculated("\n After excluding workspaces with terraform_remote_state resources, %d workspaces remain\n", len(srcWorkspaces))
 		// List the workspaces that remain
-		// for _, w := range srcWorkspaces {
-		// 	o.AddMessageUserProvided("Workspace(s) remaining:", w.Name)
-		// }
 	}
 
 	return srcWorkspaces, nil

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -4,6 +4,7 @@
 package copy
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -295,6 +296,19 @@ func getSrcWorkspacesCfg(c tfclient.ClientContexts) ([]*tfe.Workspace, error) {
 		}
 	}
 
+	// Exclude any workspaces that contain terraform_remote_state resources
+	if viper.GetBool("exclude-ws-remote-state-resources") {
+		srcWorkspaces, err = excludeWorkspaceRemoteStateResources(tfclient.GetClientContexts(), srcWorkspaces)
+		if err != nil {
+			return nil, err
+		}
+		o.AddFormattedMessageCalculated("\n After excluding workspaces with terraform_remote_state resources, %d workspaces remain\n", len(srcWorkspaces))
+		// List the workspaces that remain
+		// for _, w := range srcWorkspaces {
+		// 	o.AddMessageUserProvided("Workspace(s) remaining:", w.Name)
+		// }
+	}
+
 	return srcWorkspaces, nil
 }
 
@@ -342,7 +356,6 @@ func getSrcWorkspacesFilter(c tfclient.ClientContexts, wsList []string) ([]*tfe.
 
 		}
 	}
-
 	return srcWorkspaces, nil
 }
 
@@ -752,4 +765,45 @@ func standardizeNamingConvention(workspaceList []*tfe.Workspace, prefix string, 
 	}
 
 	return workspaceList
+}
+
+// This next section is to check if workspaces use terraform_remote_state
+func excludeWorkspaceRemoteStateResources(c tfclient.ClientContexts, workspaceList []*tfe.Workspace) ([]*tfe.Workspace, error) {
+	var updatedWorkspaceList []*tfe.Workspace
+	opts := &tfe.WorkspaceResourceListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize:   30,
+			PageNumber: 1,
+		},
+	}
+
+	for _, ws := range workspaceList {
+		fmt.Printf("\nChecking workspace for remote state resources: %s\n", ws.Name)
+		hasRemoteState := false
+		opts.ListOptions.PageNumber = 1 // reset pagination for each workspace
+
+		for {
+			resources, err := c.DestinationClient.WorkspaceResources.List(context.Background(), ws.ID, opts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list workspace resources - : %w", err)
+			}
+			for _, resource := range resources.Items {
+				// fmt.Printf(" - Found resource: %s of type %s\n", resource.Address, resource.ProviderType)
+				if resource.ProviderType == "data.terraform_remote_state" {
+					fmt.Printf("\nSkipping workspace %s due to terraform_remote_state resource\n", ws.Name)
+					hasRemoteState = true
+					break
+				}
+			}
+			if hasRemoteState || resources.Pagination.NextPage == 0 {
+				break
+			}
+			opts.ListOptions.PageNumber = resources.Pagination.NextPage
+		}
+		if !hasRemoteState {
+			updatedWorkspaceList = append(updatedWorkspaceList, ws)
+		}
+	}
+
+	return updatedWorkspaceList, nil
 }

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -782,7 +782,7 @@ func excludeWorkspaceRemoteStateResources(c tfclient.ClientContexts, workspaceLi
 		for {
 			resources, err := c.SourceClient.WorkspaceResources.List(context.Background(), ws.ID, opts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list workspace resources - : %w", err)
+				return nil, fmt.Errorf("failed to list workspace resources: %w", err)
 			}
 			for _, resource := range resources.Items {
 				if resource.ProviderType == "data.terraform_remote_state" {

--- a/cmd/copy/workspaces.go
+++ b/cmd/copy/workspaces.go
@@ -785,7 +785,7 @@ func excludeWorkspaceRemoteStateResources(c tfclient.ClientContexts, workspaceLi
 				return nil, fmt.Errorf("failed to list workspace resources - : %w", err)
 			}
 			for _, resource := range resources.Items {
-				// fmt.Printf(" - Found resource: %s of type %s\n", resource.Address, resource.ProviderType)
+				
 				if resource.ProviderType == "data.terraform_remote_state" {
 					fmt.Printf("\nSkipping workspace %s due to terraform_remote_state resource\n", ws.Name)
 					hasRemoteState = true

--- a/site/docs/configuration_file/config_file.md
+++ b/site/docs/configuration_file/config_file.md
@@ -7,7 +7,8 @@
 | src_tfe_token | A TFC/TFE Token | A Token for the TFE/TFC Organization that you are migrating from | `yes` for TFE to TFC or TFC to TFC migrations | 
 | dst_tfc_hostname | A hostname such as app.terraform.io | The hostname of a TFE server or the TFC hostname that you are migrating to | `yes` for all migrations | 
 | dst_tfc_org | A TFC/TFE organization name | A TFC/TFE organization that you are migrating to | `yes` for all migrations | 
-| dst_tfc_token | A TFC/TFE Token | | `yes` for all migrations | 
+| dst_tfc_token | A TFC/TFE Token | A Token for the TFE/TFC Organization that you are migrating to | `yes` for all migrations | 
+| exclude-ws-remote-state-resources | true/false | Option to skip workspaces which use [remote state data](https://developer.hashicorp.com/terraform/language/state/remote-state-data). | `no`| 
 | repos_to_clone | A list of VCS repository names | Used with the`tfm core clone` command to clone a set of VCS repositories. If not provided, all VCS repos will be cloned | `no` | 
 | vcs-map | A list of source=destination VCS oauth IDs | TFM will look at each workspace in the source for the source VCS oauth ID and assign the matching workspace in the destination with the destination VCS oauth ID | `yes` for `tfm copy workspaces --vcs` |
 | workspaces | A list of workspaces to migrate from TFE to TFC or TFC org to TFC org | Provide a list of source workspaces in the source TFC/TFE org to migrate. If not provided and no "workspaces-map" is detected, all workspaces will be migrated. | `no` |


### PR DESCRIPTION
This pull request introduces a new feature that allows users to exclude workspaces containing `terraform_remote_state` resources during migration. The main changes include updates to the configuration documentation and the implementation of the exclusion logic in the workspace copying process.

**Feature: Exclude workspaces with remote state resources**

* Configuration documentation (`site/docs/configuration_file/config_file.md`): Added the `exclude-ws-remote-state-resources` option to allow skipping workspaces that use remote state data resources.
* Workspace filtering logic (`cmd/copy/workspaces.go`): Implemented the `excludeWorkspaceRemoteStateResources` function to remove workspaces containing `terraform_remote_state` resources from the migration list.
* Workspace selection (`cmd/copy/workspaces.go`): Integrated the exclusion feature into the `getSrcWorkspacesCfg` function, applying the filter when the configuration option is enabled.

**Technical improvements**

* Added the `context` package import to support context-aware resource listing in workspace operations. (`cmd/copy/workspaces.go`)