### PR TITLE
docs(changelog): backfill missing entries for 0.15.0, 0.15.1, 0.16.0 and sync version.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set `User-Agent` header on source and destination TFE clients to identify `tfm` in API requests ([#321](https://github.com/hashicorp-services/tfm/pull/321))
 
-## [0.15.0](https://github.com/hashicorp-services/tfm/compare/0.14.0...0.15.0) (2025-07-14)
+## [0.15.0](https://github.com/hashicorp-services/tfm/compare/v0.14.0...v0.15.0) (2025-07-14)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0](https://github.com/hashicorp-services/tfm/compare/0.15.1...0.16.0) (2025-09-16)
+
+### Features
+
+- Add option to exclude workspaces that contain `terraform_remote_state` resources from migration ([#335](https://github.com/hashicorp-services/tfm/pull/335))
+
+### Enhancements
+
+- Propagate workspace `name_prefix` and `name_suffix` transformations to all workspace copy sub-commands: run-triggers, state-sharing, states, team-access, and vars ([#331](https://github.com/hashicorp-services/tfm/pull/331))
+- Add `demo/` directory to `.gitignore`
+
+## [0.15.1](https://github.com/hashicorp-services/tfm/compare/0.15.0...0.15.1) (2025-07-28)
+
+### Bug Fixes
+
+- Set `User-Agent` header on source and destination TFE clients to identify `tfm` in API requests ([#321](https://github.com/hashicorp-services/tfm/pull/321))
+
+## [0.15.0](https://github.com/hashicorp-services/tfm/compare/0.14.0...0.15.0) (2025-07-14)
+
+### Features
+
+- Add `lock teams` command to lock team permissions across an organization ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Add `--plan-only` flag to `copy workspaces` for dry-run functionality without making changes ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Add `--workspace-name-prefix` and `--workspace-name-suffix` flags to `copy workspaces` for workspace renaming during migration ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Add `--skip-empty-workspaces` flag to `copy workspaces` to skip workspaces with no resources ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Add `--create-destination-project` flag to `copy workspaces` to create the destination project if it does not exist ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Validate workspace name length and apply tags during migration ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+
+### Enhancements
+
+- Refactor project creation logic into a reusable function ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+- Update `copy teams` to support org-to-project migration patterns ([#317](https://github.com/hashicorp-services/tfm/pull/317))
+
+### Chore
+
+- Add `.DS_Store` to `.gitignore`
+
 ## [0.14.0](https://github.com/hashicorp-services/tfm/compare/v0.13.0...v0.14.0) (2025-05-16)
 
 ### Features

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@
 package version
 
 var (
-	Version    = "0.14.0"
+	Version    = "0.16.0"
 	Prerelease = ""
 	Build      = ""
 	Date       = ""


### PR DESCRIPTION
## Summary

Backfills the `CHANGELOG.md` which has not been updated since `0.14.0`, and syncs `version/version.go` to the current release tag.

### Changes

#### `CHANGELOG.md`
Adds missing entries for all releases between `0.14.0` and the current tag `0.16.0`:

| Release | Date | Highlights |
|---------|------|-----------|
| **0.15.0** | 2025-07-14 | `lock teams` command; `--plan-only` (dry-run) flag; `--workspace-name-prefix/suffix` flags; `--skip-empty-workspaces`; `--create-destination-project` (#317) |
| **0.15.1** | 2025-07-28 | Set `User-Agent` header on TFE clients (#321) |
| **0.16.0** | 2025-09-16 | Exclude workspaces with `terraform_remote_state` (#335); propagate prefix/suffix to all workspace copy sub-commands (#331) |

#### `version/version.go`
Bumped from `0.14.0` → `0.16.0` to match the current tag.

> **Note:** GoReleaser already injects the correct version at build time via `ldflags` (`-X ...version.Version={{ .Version }}`), so released binaries are always correct regardless of this file. This change is a local-dev quality-of-life fix so `go run . -v` reports the right version.

---

## Next Steps

Once this PR is reviewed and merged, the repo is ready to tag `0.16.1` (dependency-only patch release). Tagging will trigger the `release.yml` workflow and GoReleaser will handle the rest.

> ⚠️ Do **not** tag until this PR is merged.