### PR TITLE
feat(ci): add workflow to update homebrew-tap formula on release

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,179 @@
+name: Update Homebrew Tap Formula
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to use (e.g. v0.17.0). Defaults to latest release."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  update-homebrew-formula:
+    name: Update hashicorp/homebrew-tap
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+          elif [ -n "${{ github.event.release.tag_name }}" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(gh release view --repo hashicorp-services/tfm --json tagName -q .tagName)
+          fi
+          # Strip leading 'v' for use in file names and formula version field
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download release checksums
+        id: checksums
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          CHECKSUM_URL="https://github.com/hashicorp-services/tfm/releases/download/${TAG}/tfm_${VERSION}_checksums.txt"
+          curl -fsSL "$CHECKSUM_URL" -o checksums.txt
+          cat checksums.txt
+
+          # Extract per-platform SHA256 values
+          darwin_arm64=$(awk '/tfm_darwin_arm64$/ {print $1}' checksums.txt)
+          darwin_x86_64=$(awk '/tfm_darwin_x86_64$/ {print $1}' checksums.txt)
+          linux_arm64=$(awk '/tfm_linux_arm64$/ {print $1}' checksums.txt)
+          linux_x86_64=$(awk '/tfm_linux_x86_64$/ {print $1}' checksums.txt)
+
+          {
+            echo "darwin_arm64=$darwin_arm64"
+            echo "darwin_x86_64=$darwin_x86_64"
+            echo "linux_arm64=$linux_arm64"
+            echo "linux_x86_64=$linux_x86_64"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate formula
+        id: formula
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          DARWIN_ARM64="${{ steps.checksums.outputs.darwin_arm64 }}"
+          DARWIN_X86_64="${{ steps.checksums.outputs.darwin_x86_64 }}"
+          LINUX_ARM64="${{ steps.checksums.outputs.linux_arm64 }}"
+          LINUX_X86_64="${{ steps.checksums.outputs.linux_x86_64 }}"
+          BASE_URL="https://github.com/hashicorp-services/tfm/releases/download/${TAG}"
+
+          cat > tfm.rb <<FORMULA
+          # Copyright (c) HashiCorp Services, Inc.
+          # SPDX-License-Identifier: MPL-2.0
+
+          class Tfm < Formula
+            desc "CLI tool for Terraform Cloud / Terraform Enterprise migration and administration"
+            homepage "https://github.com/hashicorp-services/tfm"
+            version "${VERSION}"
+
+            if OS.mac? && Hardware::CPU.intel?
+              url "${BASE_URL}/tfm_darwin_x86_64"
+              sha256 "${DARWIN_X86_64}"
+            end
+
+            if OS.mac? && Hardware::CPU.arm?
+              url "${BASE_URL}/tfm_darwin_arm64"
+              sha256 "${DARWIN_ARM64}"
+            end
+
+            if OS.linux? && Hardware::CPU.intel?
+              url "${BASE_URL}/tfm_linux_x86_64"
+              sha256 "${LINUX_X86_64}"
+            end
+
+            if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+              url "${BASE_URL}/tfm_linux_arm64"
+              sha256 "${LINUX_ARM64}"
+            end
+
+            def install
+              # Release assets are raw binaries (not archives); the downloaded file name
+              # matches the asset name from the release.  Rename it to the canonical
+              # binary name during install.
+              os_arch = if OS.mac? && Hardware::CPU.arm?
+                "darwin_arm64"
+              elsif OS.mac?
+                "darwin_x86_64"
+              elsif Hardware::CPU.arm?
+                "linux_arm64"
+              else
+                "linux_x86_64"
+              end
+              bin.install "tfm_\#{os_arch}" => "tfm"
+            end
+
+            test do
+              assert_match "tfm version \#{version}", shell_output("\#{bin}/tfm --version")
+            end
+          end
+          FORMULA
+
+          # Strip the leading indentation introduced by the heredoc
+          sed -i 's/^          //' tfm.rb
+          cat tfm.rb
+
+      - name: Push formula to homebrew-tap and open PR
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          BRANCH="chore/bump-tfm-${VERSION}"
+
+          # Retrieve current master SHA for the tap
+          MASTER_SHA=$(gh api repos/hashicorp/homebrew-tap/git/refs/heads/master --jq '.object.sha')
+
+          # Create feature branch (ignore error if branch already exists)
+          gh api --method POST repos/hashicorp/homebrew-tap/git/refs \
+            --field ref="refs/heads/${BRANCH}" \
+            --field sha="$MASTER_SHA" 2>/dev/null || true
+
+          # Retrieve existing file SHA if present (required for update)
+          EXISTING_SHA=$(gh api "repos/hashicorp/homebrew-tap/contents/Formula/tfm.rb?ref=${BRANCH}" \
+            --jq '.sha' 2>/dev/null || echo "")
+
+          # Base64-encode formula content
+          CONTENT=$(base64 -w0 tfm.rb)
+
+          if [ -n "$EXISTING_SHA" ]; then
+            gh api --method PUT repos/hashicorp/homebrew-tap/contents/Formula/tfm.rb \
+              --field message="chore(tfm): bump tfm to ${VERSION}" \
+              --field "content=$CONTENT" \
+              --field branch="$BRANCH" \
+              --field sha="$EXISTING_SHA"
+          else
+            gh api --method PUT repos/hashicorp/homebrew-tap/contents/Formula/tfm.rb \
+              --field message="chore(tfm): bump tfm to ${VERSION}" \
+              --field "content=$CONTENT" \
+              --field branch="$BRANCH"
+          fi
+
+          # Open PR (skip if one already exists for this branch)
+          EXISTING_PR=$(gh pr list --repo hashicorp/homebrew-tap \
+            --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$EXISTING_PR" ]; then
+            printf 'Automated formula update for [tfm](https://github.com/hashicorp-services/tfm) %s.\n\n- Source release: https://github.com/hashicorp-services/tfm/releases/tag/%s\n- Triggered by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              "$TAG" "$TAG" > pr_body.txt
+
+            gh pr create \
+              --repo hashicorp/homebrew-tap \
+              --head "$BRANCH" \
+              --base master \
+              --title "chore(tfm): bump tfm to ${VERSION}" \
+              --body-file pr_body.txt
+          else
+            echo "PR already exists: #${EXISTING_PR}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically updates the `tfm` formula in [hashicorp/homebrew-tap](https://github.com/hashicorp/homebrew-tap) whenever a new release is published.

Closes #47

## Changes

- **New file:** `.github/workflows/update-homebrew-tap.yml`

## How it works

1. Triggers on `release: released` events (also supports `workflow_dispatch` with an optional tag input for manual runs)
2. Downloads `tfm_<version>_checksums.txt` from the release assets
3. Generates a fresh `Formula/tfm.rb` with the updated version and per-platform SHA256 hashes
4. Creates a branch `chore/bump-tfm-<version>` in `hashicorp/homebrew-tap` via the GitHub API
5. Opens a PR in `hashicorp/homebrew-tap` for the tap maintainers to review and merge

## Required setup

Before this workflow can run, add a repository secret named **`HOMEBREW_TAP_TOKEN`** in `hashicorp-services/tfm` Settings → Secrets:

- **Type:** Classic PAT (or fine-grained PAT with Contents + Pull Requests read/write on `hashicorp/homebrew-tap`)
- **Scopes needed (classic PAT):** `repo` (write access to `hashicorp/homebrew-tap`)

## Related

- Initial formula PR in homebrew-tap: https://github.com/hashicorp/homebrew-tap/pull/369